### PR TITLE
Add simple health endpoint

### DIFF
--- a/cerabrasileira-store/src/api/health/route.ts
+++ b/cerabrasileira-store/src/api/health/route.ts
@@ -1,0 +1,8 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+export async function GET(
+  req: MedusaRequest,
+  res: MedusaResponse
+) {
+  res.sendStatus(200);
+}


### PR DESCRIPTION
## Summary
- add health API route responding with status 200

## Testing
- `npm run test:integration:http` *(fails: Cannot use 'in' operator to search for 'cause' in Cannot read properties of null (reading 'resolve'))*
- `npm run test:unit` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aa941e6c8329b7d509cb0fc70dad