### PR TITLE
feat: add currency formatting util and tests

### DIFF
--- a/cerabrasileira-storefront/src/lib/util/__tests__/format-currency.test.ts
+++ b/cerabrasileira-storefront/src/lib/util/__tests__/format-currency.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { formatCurrency } from "../money"
+
+test("formats currency using en-US locale", () => {
+  const formatted = formatCurrency(1234.56, "USD", "en-US")
+  assert.equal(formatted, "$1,234.56")
+})
+
+test("formats currency using provided locale", () => {
+  const formatted = formatCurrency(1234.56, "EUR", "de-DE")
+  // de-DE locale uses non-breaking space before the currency symbol
+  assert.equal(formatted, "1.234,56\u00a0€")
+})
+
+test("falls back to raw amount when currency code missing", () => {
+  const formatted = formatCurrency(1234.56, "")
+  assert.equal(formatted, "1234.56")
+})
+

--- a/cerabrasileira-storefront/src/lib/util/money.ts
+++ b/cerabrasileira-storefront/src/lib/util/money.ts
@@ -24,3 +24,16 @@ export const convertToLocale = ({
       }).format(amount)
     : amount.toString()
 }
+
+export const formatCurrency = (
+  amount: number,
+  currencyCode: string,
+  locale = "en-US"
+) => {
+  return currencyCode && !isEmpty(currencyCode)
+    ? new Intl.NumberFormat(locale, {
+        style: "currency",
+        currency: currencyCode,
+      }).format(amount)
+    : amount.toString()
+}


### PR DESCRIPTION
## Summary
- add formatCurrency utility for locale-aware money formatting
- cover formatting util with node-based tests

## Testing
- `node --loader ../cerabrasileira-store/node_modules/ts-node/esm.mjs --test src/lib/util/__tests__/format-currency.test.ts` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe1acbc3c832984156957a78ee998