### PR TITLE
test: add Playwright checkout tests

### DIFF
--- a/cerabrasileira-storefront/package.json
+++ b/cerabrasileira-storefront/package.json
@@ -36,6 +36,7 @@
     "@babel/core": "^7.17.5",
     "@medusajs/types": "latest",
     "@medusajs/ui-preset": "latest",
+    "@playwright/test": "^1.51.1",
     "@types/lodash": "^4.14.195",
     "@types/node": "17.0.21",
     "@types/pg": "^8.11.0",

--- a/cerabrasileira-storefront/playwright.config.ts
+++ b/cerabrasileira-storefront/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:8000',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 8000,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/cerabrasileira-storefront/tests/checkout.spec.ts
+++ b/cerabrasileira-storefront/tests/checkout.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+// Tests checkout flow using Midtrans sandbox
+// Mocks Midtrans network to simulate success and failure cases
+
+test.describe('checkout', () => {
+  test('completes order successfully', async ({ page }) => {
+    await page.route('https://app.sandbox.midtrans.com/**', (route) => {
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+    await page.route('**/store/carts/*/complete', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          type: 'order',
+          order: { id: 'order_test', shipping_address: { country_code: 'us' } },
+        }),
+      });
+    });
+
+    await page.goto('/us/checkout?step=review');
+    await page.getByTestId('submit-order-button').click();
+    await expect(page).toHaveURL(/\/us\/order\/order_test\/confirmed$/);
+  });
+
+  test('shows error when Midtrans fails', async ({ page }) => {
+    await page.route('https://app.sandbox.midtrans.com/**', (route) => {
+      route.abort();
+    });
+    await page.route('**/store/carts/*/complete', (route) => {
+      route.fulfill({ status: 500, body: 'fail' });
+    });
+
+    await page.goto('/us/checkout?step=review');
+    await page.getByTestId('submit-order-button').click();
+    await expect(page.getByTestId('manual-payment-error-message')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright setup for storefront
- cover checkout flow with Midtrans sandbox success and failure

## Testing
- `npx playwright test` (fails: 403 Forbidden retrieving Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68bbe55bc44c83298d6bcae28a81a3c2